### PR TITLE
fix: Use Jupyter Book v0.8.X API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Jupyter Book
 _build/
+
+# Downloaded archives
+*.tar
+*.gz

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -1,8 +1,9 @@
 # https://jupyterbook.org/customize/toc.html
 - file: introduction
 
-- header: Get started
-- file: HistFactory
-- file: inference
-- file: serialization
-- file: visualization
+- part: Get started
+  chapters:
+  - file: HistFactory
+  - file: inference
+  - file: serialization
+  - file: visualization

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book~=0.7
+jupyter-book~=0.8.0


### PR DESCRIPTION
```
* Require Jupyter Book v0.8.X
   - Pin to patch version until stable API with v1.0
* Use v0.8 part API
   - c.f. https://jupyterbook.org/customize/toc.html
* Ignore tar files and gzip files
```